### PR TITLE
Fixed error : Initialize a parameter

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -81,7 +81,7 @@ function Strategy(options, verify) {
     options = {};
   }
   if (!verify) { throw new TypeError('HTTPBearerStrategy requires a verify callback'); }
-  
+
   passport.Strategy.call(this);
   this.name = 'custom-bearer';
   this._verify = verify;
@@ -118,7 +118,7 @@ Strategy.prototype.authenticate = function(req) {
     if (parts.length == 2) {
       var scheme = parts[0]
         , credentials = parts[1];
-        
+
       if (/^Bearer$/i.test(scheme)) {
         token = credentials;
       }
@@ -136,18 +136,18 @@ Strategy.prototype.authenticate = function(req) {
     if (token) { return this.fail(400); }
     token = req.query[this._queryName];
   }
-  
+
   if (!token) { return this.fail(this._challenge()); }
-  
+
   var self = this;
-  
+
   function verified(err, user, info) {
+    info = info || {};
     if (err) { return self.error(err); }
     if (!user) {
       if (typeof info == 'string') {
-        info = { message: info }
+        info = { message: info };
       }
-      info = info || {};
       return self.fail(self._challenge('invalid_token', info.message));
     }
     info['headerName'] = self._headerName;
@@ -156,7 +156,7 @@ Strategy.prototype.authenticate = function(req) {
 
     self.success(user, info);
   }
-  
+
   if (self._passReqToCallback) {
     this._verify(req, token, verified);
   } else {
@@ -183,7 +183,7 @@ Strategy.prototype._challenge = function(code, desc, uri) {
   if (uri && uri.length) {
     challenge += ', error_uri="' + uri + '"';
   }
-  
+
   return challenge;
 };
 


### PR DESCRIPTION
### Description 

I changed the location of a line of code to fix my error. 
I am using Nest.js framework and tried to use the Authentication guard.
Since the bearer passport worked well, I changed it to custom bearer passport, but an error occurred.
``
[Nest] 61843  - 06/20/2022, 4:42:16 PM   ERROR [ExceptionsHandler] Cannot set property 'headerName' of undefined
TypeError: Cannot set property 'headerName' of undefined
    at verified (/node_modules/passport-http-custom-bearer/lib/strategy.js:156:24)
    at CustomBearerStrategy.<anonymous> (/node_modules/@nestjs/passport/dist/passport/passport.strategy.js:25:25)
    at Generator.next (<anonymous>)
    at fulfilled (/node_modules/@nestjs/passport/dist/passport/passport.strategy.js:5:58)
``

The reason for the error was that the info delivered as a parameter to the verified function was an undefined value. If the info is not delivered, the info should be initialized as an empty object. I moved the corresponding source code to the top of the function.

